### PR TITLE
Fixes an error that's thrown if certain variables don't exist

### DIFF
--- a/lib/templates/vendor.tpl
+++ b/lib/templates/vendor.tpl
@@ -42,7 +42,7 @@
 	{rb}
 
 	function runGoogleAnalytics(path) {lb}
-		if (ga) {lb}
+		if (typeof ga === 'function') {lb}
 			ga('set', 'page', path);
 			ga('send', 'pageview');
 		{rb}
@@ -51,7 +51,7 @@
 	runCodeMirror();
 
 	document.addEventListener('DOMContentLoaded', function() {lb}
-		if (senna) {lb}
+		if (typeof senna !== 'undefined') {lb}
 			var app = senna.dataAttributeHandler.getApp();
 			app.on('endNavigate', function(event) {lb}
 				disposePageComponent();


### PR DESCRIPTION
This fixes an issue where if the variables don't exist on the page, it will throw an error.

To reproduce, just simply add a frontMatterHook property to your electric.config.js file like so:

```js
      frontMatterHook: function(data) {
		delete data.googleAnalytics;
		return data;
	},
```

And then navigate around a page. This makes it so that if the script's aren't loaded, it won't throw the JS error.