### PR TITLE
Add parameter to inform where the scss files are going to be located

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -55,6 +55,7 @@ function normalizeOptions(options) {
 	];
 	options.pathDest = options.pathDest || 'dist';
 	options.pathSrc = options.pathSrc || 'src';
+	options.scssSrc = options.scssSrc || 'styles';
 	options.plugins = options.plugins || [];
 	options.port = options.port || 8888;
 	options.taskPrefix = options.taskPrefix || '';

--- a/lib/tasks/styles.js
+++ b/lib/tasks/styles.js
@@ -9,10 +9,11 @@ module.exports = function(options) {
 	let pathSrc = options.pathSrc;
 	let sassOptions = options.sassOptions;
 	let taskPrefix = options.taskPrefix;
-
+	let scssSrc = options.scssSrc + '/**/*.scss';
+	
 	gulp.task(taskPrefix + 'styles', function() {
 		return gulp
-			.src(path.join(pathSrc, 'styles/**/*.scss'))
+			.src(path.join(pathSrc, scssSrc))
 			.pipe(sass(sassOptions).on('error', sass.logError))
 			.pipe(gulp.dest(path.join(pathDest, 'styles')));
 	});

--- a/lib/tasks/styles.js
+++ b/lib/tasks/styles.js
@@ -9,8 +9,8 @@ module.exports = function(options) {
 	let pathSrc = options.pathSrc;
 	let sassOptions = options.sassOptions;
 	let taskPrefix = options.taskPrefix;
-	let scssSrc = options.scssSrc + '/**/*.scss';
-	
+  let scssSrc = `${options.scssSrc}/**/*.scss`;
+
 	gulp.task(taskPrefix + 'styles', function() {
 		return gulp
 			.src(path.join(pathSrc, scssSrc))


### PR DESCRIPTION
I've implemented a 'scssSrc' parameter in case the user needs to use a different entry folder for his scss files.

More details on issue: https://github.com/electricjs/electric/issues/61