### PR TITLE
Add parameter to inform where the scss files are going to be located

### DIFF
--- a/packages/electric/lib/options.js
+++ b/packages/electric/lib/options.js
@@ -53,6 +53,8 @@ function normalizeOptions(options) {
 	options = applyConfigFile(options);
 
 	options = applyEnv(options);
+	
+	options.scssSrc = options.scssSrc || 'styles';
 
 	let basePath = options.basePath || '';
 

--- a/packages/electric/lib/tasks/styles.js
+++ b/packages/electric/lib/tasks/styles.js
@@ -9,10 +9,11 @@ module.exports = function(options) {
 	const pathSrc = options.pathSrc;
 	const sassOptions = options.sassOptions;
 	const taskPrefix = options.taskPrefix;
+	const scssSrc = `${options.scssSrc}/**/*.scss`;
 
 	gulp.task(taskPrefix + 'styles', function() {
 		return gulp
-			.src(path.join(pathSrc, 'styles/**/*.scss'))
+			.src(path.join(pathSrc, scssSrc))
 			.pipe(sass(sassOptions).on('error', sass.logError))
 			.pipe(gulp.dest(path.join(pathDest, 'styles')));
 	});


### PR DESCRIPTION
I've implemented a 'scssSrc' parameter in case the user needs to use a different entry folder for his scss files.

More details on issue: #61