### PR TITLE
Allows passing resolve.modules to webpack bundle for scenarios such as hoisted lerna project layouts where plugins like commonchunks will fail to properly dedupe and extract common classes

### DIFF
--- a/packages/electric/lib/options.js
+++ b/packages/electric/lib/options.js
@@ -91,6 +91,7 @@ function normalizeOptions(options) {
 	options.pathSrc = options.pathSrc || 'src';
 	options.plugins = options.plugins || [];
 	options.port = options.port || 8888;
+	options.resolveModules = options.resolveModules || ['node_modules'];
 	options.rss = _.assign(
 		{
 			enabled: false

--- a/packages/electric/lib/pipelines/bundle.js
+++ b/packages/electric/lib/pipelines/bundle.js
@@ -10,6 +10,7 @@ function bundle(options) {
 	options = options || {};
 
 	const entries = options.entryPoints || {};
+	const modules = options.modules || ['node_modules'];
 	const uglify = options.uglify || false;
 
 	return through.obj(
@@ -71,7 +72,10 @@ function bundle(options) {
 						library: 'pageComponent',
 						path: path.join(process.cwd(), options.dest, 'js', 'bundles')
 					},
-					plugins: plugins
+					plugins: plugins,
+					resolve: {
+						modules: modules
+					}
 				},
 				function(err) {
 					cb(err);

--- a/packages/electric/lib/tasks/metal.js
+++ b/packages/electric/lib/tasks/metal.js
@@ -157,6 +157,7 @@ module.exports = function(options) {
 					bundle({
 						dest: pathDest,
 						entryPoints: options.entryPoints,
+						modules: options.resolveModules,
 						uglify: options.uglifyBundle
 					})
 				);


### PR DESCRIPTION
Hey @Robert-Frampton, this addresses https://github.com/electricjs/electric/issues/98 which we need to be able to properly merge and build https://github.com/metal/metal-clay-components/pull/239

What do you think?