### PR TITLE
Adds support for customizing the main folder name for unZip export | Fixes #123

### DIFF
--- a/packages/electric/lib/download.js
+++ b/packages/electric/lib/download.js
@@ -37,6 +37,7 @@ function projectDownload(project, cb) {
 		project.refs,
 		function(ref, done) {
 			const pathProject = path.join(process.cwd(), '.temp', 'project');
+			const mainFolderName = project.mainFolderName || 'src';
 
 			fs.ensureDirSync(pathProject);
 
@@ -67,11 +68,11 @@ function projectDownload(project, cb) {
 						readableStream.pipe(writableStream);
 
 						writableStream.on('finish', function () {
-							const pathUnZip = path.join(pathProject, ref, 'src');
+							const pathUnZip = path.join(pathProject, ref, mainFolderName);
 
 							fs.ensureDirSync(pathUnZip);
 
-							projectUnzip(zipPath, `${project.repo}-${cleanRef}/src/`, pathUnZip, done);
+							projectUnzip(zipPath, `${project.repo}-${cleanRef}/${mainFolderName}/`, pathUnZip, done);
 						});
 
 						writableStream.on('error', function (err) {

--- a/packages/electric/lib/download.js
+++ b/packages/electric/lib/download.js
@@ -37,7 +37,7 @@ function projectDownload(project, cb) {
 		project.refs,
 		function(ref, done) {
 			const pathProject = path.join(process.cwd(), '.temp', 'project');
-			const mainFolderName = project.mainFolderName || 'src';
+			const srcPath = project.srcPath || 'src';
 
 			fs.ensureDirSync(pathProject);
 
@@ -68,11 +68,11 @@ function projectDownload(project, cb) {
 						readableStream.pipe(writableStream);
 
 						writableStream.on('finish', function () {
-							const pathUnZip = path.join(pathProject, ref, mainFolderName);
+							const pathUnZip = path.join(pathProject, ref, srcPath);
 
 							fs.ensureDirSync(pathUnZip);
 
-							projectUnzip(zipPath, `${project.repo}-${cleanRef}/${mainFolderName}/`, pathUnZip, done);
+							projectUnzip(zipPath, `${project.repo}-${cleanRef}/${srcPath}/`, pathUnZip, done);
 						});
 
 						writableStream.on('error', function (err) {


### PR DESCRIPTION
> I did not think of a better name for this API, please if you have something better in mind, feel free to.

### New
* Adds to `apiConfig.project` **mainFolderName** to customize the main project folder for extraction.
